### PR TITLE
Reload page when running out-of-date code

### DIFF
--- a/app/assets/javascripts/channels/cast.js
+++ b/app/assets/javascripts/channels/cast.js
@@ -1,22 +1,33 @@
-App.cast = App.cable.subscriptions.create("CastChannel", {
-  connected: function() {
-    writeLog('Connected');
-  },
+App.cast = App.cable.subscriptions.create({
+    channel: 'CastChannel',
+    code_version: App.CODE_VERSION
+  }, {
+    connected: function() {
+      writeLog('Connected');
+    },
 
-  disconnected: function() {
-    writeLog('Disconnected');
-  },
+    disconnected: function() {
+      writeLog('Disconnected');
+    },
 
-  received: function(data) {
-    writeLog('Received message: ' + JSON.stringify(data));
+    rejected: function() {
+      writeLog('Detected running out-of-date code. Reloading...');
 
-    switch(data.command) {
-    case 'sound':
-      playSound(data.args.url, data.args.reverse, data.args.delay);
-      break;
-    case 'image':
-      setCoverImage(data.args.url);
-      break;
+      setTimeout(function() {
+        window.location.reload();
+      }, 1000);
+    },
+
+    received: function(data) {
+      writeLog('Received message: ' + JSON.stringify(data));
+
+      switch(data.command) {
+      case 'sound':
+        playSound(data.args.url, data.args.reverse, data.args.delay);
+        break;
+      case 'image':
+        setCoverImage(data.args.url);
+        break;
+      }
     }
-  }
 });

--- a/app/channels/cast_channel.rb
+++ b/app/channels/cast_channel.rb
@@ -1,8 +1,16 @@
 class CastChannel < ApplicationCable::Channel
+  before_subscribe :check_code_version
+
   def subscribed
     stream_from ReceiveSlashCommand::CHANNEL
   end
 
   def unsubscribed
+  end
+
+  private
+
+  def check_code_version
+    reject unless params[:code_version] == GetCodeVersion.call
   end
 end

--- a/app/services/get_code_version.rb
+++ b/app/services/get_code_version.rb
@@ -1,0 +1,7 @@
+class GetCodeVersion
+  def self.call
+    return ENV['HEROKU_RELEASE_VERSION'] if ENV['HEROKU_RELEASE_VERSION']
+
+    @code_version ||= SecureRandom.hex
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,17 @@
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>
     <%= yield %>
   </body>
+
+
+  <script type="text/javascript">
+    window.App = window.App || {};
+    App.CODE_VERSION = '<%= GetCodeVersion.call %>';
+  </script>
+
+  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 </html>

--- a/spec/services/get_code_version_spec.rb
+++ b/spec/services/get_code_version_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe GetCodeVersion do
+  subject(:code_version) { described_class.call }
+
+  context 'on Heroku' do
+    before { ENV['HEROKU_RELEASE_VERSION'] = 'v1' }
+
+    it { is_expected.to eq 'v1' }
+  end
+
+  context 'not on Heroku' do
+    it { is_expected.to be_an_instance_of(String) }
+
+    it 'does not change once set' do
+      expect(described_class.call).to eq code_version
+    end
+  end
+end


### PR DESCRIPTION
Detect if client-side code is out-of-date when subscribing to `ActionCable`, and reload page if so.

This enables one-touch deployment and browser reloading using `git push heroku master`.